### PR TITLE
Bug 1878163: Updating openshift-enterprise-service-idler builder & base images to be consistent with ART

### DIFF
--- a/images/service-idler/Dockerfile
+++ b/images/service-idler/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-base
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
 RUN INSTALL_PKGS="origin-service-idler" && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \


### PR DESCRIPTION
Updating openshift-enterprise-service-idler builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/openshift-enterprise-service-idler.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
