### PR TITLE
Bug 1949882: Fix build error with Go 1.16

### DIFF
--- a/service-idler.spec
+++ b/service-idler.spec
@@ -45,7 +45,9 @@ ln -s $(pwd) gopath/src/%{import_path}
 export GOPATH=$(pwd)/gopath
 
 # actually build
-go build -o service-idler %{import_path}/cmd/service-idler
+# From Go 1.16, the go command builds packages in module-aware mode by default, even when no go.mod is present.
+# Setting GO111MODULE=auto allows to continue to build this package in GOPATH mode.
+GO111MODULE=auto go build -o service-idler %{import_path}/cmd/service-idler
 
 %install
 install -d %{buildroot}%{_bindir}


### PR DESCRIPTION
A build error occurs when we build service-idler for OCP 4.8, which uses a Go 1.16 compiler.

``` sh
$ go build -o service-idler github.com/openshift/service-idler/cmd/service-idler
no required module provides package github.com/openshift/service-idler/cmd/service-idler: working directory is not part of a module
```

According to https://blog.golang.org/go116-module-changes,
Go 1.16 builds packages in module-aware mode by default, even when no go.mod is present.
This results in a build error in Go 1.16.

This PR temporarily sets `GO111MODULE=auto` to continue to build this package in GOPATH mode.

Note Go team plans to drop support for GOPATH mode in Go 1.17. Please migrate to Go Modules before that happens.

Note this doesn't break 3.11 build because old golang builder just ignores the env var.