### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,19 @@
+reviewers:
+  - JacobTanenbaum
+  - abhat
+  - alexanderConstantinescu
+  - aojea
+  - danwinship
+  - dcbw
+  - dougbtv
+  - s1061123
+  - squeed
+  - tssurya
+  - vpickard
+approvers:
+  - abhat
+  - danwinship
+  - dcbw
+  - knobunc
+  - squeed
+  - trozet


### PR DESCRIPTION
This is a lightly pruned version of the sdn OWNERS since the SDN team owns the idler.